### PR TITLE
handle [issue #3](https://github.com/SLaks/Minimatch/issues/3)  

### DIFF
--- a/Minimatch/Minimatcher.cs
+++ b/Minimatch/Minimatcher.cs
@@ -960,7 +960,7 @@ namespace Minimatch
                             // can't swallow "." or ".." ever.
                             // can only swallow ".foo" when explicitly asked.
                             if (swallowee == "." || swallowee == ".." ||
-                                (!options.Dot && swallowee[0] == '.'))
+                                (!options.Dot && !string.IsNullOrEmpty(swallowee) && swallowee[0] == '.'))
                             {
                                 //if (options.debug)
                                 //  console.error("dot detected!", file, fr, pattern, pr)


### PR DESCRIPTION
Singular focused Pull request to fix  [issue #3](https://github.com/SLaks/Minimatch/issues/3)   - "FolderName\" fails with empty string. This should get swallowed like "."