### PR TITLE
Set up CI with Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,24 @@
+trigger:
+- master
+
+variables:
+  configuration: Release
+
+jobs:
+  - job: Build
+    pool:
+      vmImage: 'Ubuntu-16.04'
+    steps:
+    - script: |
+        npx -q git2semver
+      displayName: Generate version number
+    - script: |
+        dotnet restore
+        dotnet build --configuration $(configuration) -p:VersionPrefix=$GIT2SEMVER_MAJORMINORPATCH
+        dotnet test
+        dotnet pack --configuration $(configuration) -p:VersionPrefix=$GIT2SEMVER_MAJORMINORPATCH
+      displayName: Build, test, and package    
+    - task: PublishPipelineArtifact@0
+      inputs:
+        artifactName: drop
+        targetPath: Minimatch/bin/$(configuration)

--- a/git2semver.config.js
+++ b/git2semver.config.js
@@ -1,0 +1,4 @@
+module.exports = (policy) => {
+    policy.useMainline('major:', 'minor:', 'patch:');
+    policy.useFormatter('majorminorpatch-pipelines-variables-and-label');
+};


### PR DESCRIPTION
Hi @SLaks - I'm on the Azure DevOps team, we use Minimatch in a few areas of our service. We were looking at a dependency issue the other day and noticed that the published version of Minimatch 2.0.0 includes a reference to a release candidate build of .NET Standard 1.0.

I thought I would submit a PR that adds CI support for the library which based on the Azure Pipelines hosted agent will reference .NET Standard 1.6.

This PR also enables automatic semantic versioning for the library based on the suffix of the commit message (major, minor, patch).