### PR TITLE
Update to .NET Standard 2.0

### DIFF
--- a/Minimatch/Minimatch.csproj
+++ b/Minimatch/Minimatch.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>Minimatch</AssemblyTitle>
     <VersionPrefix>2.0.0</VersionPrefix>
     <Authors>SLaks</Authors>
-    <TargetFramework>netstandard1.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Minimatch</AssemblyName>
     <AssemblyOriginatorKeyFile>Minimatch.snk</AssemblyOriginatorKeyFile>
@@ -14,7 +14,7 @@
     <PackageId>Minimatch</PackageId>
     <PackageTags>strings;glob;search;files;wildcards;patterns</PackageTags>
     <PackageReleaseNotes>Repackaged with .Net Platform Standard</PackageReleaseNotes>
-    <PackageLicenseUrl>http://opensource.org/licenses/MIT</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/SLaks/Minimatch/</RepositoryUrl>
   </PropertyGroup>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,24 @@
+trigger:
+- master
+
+variables:
+  configuration: Release
+
+jobs:
+  - job: Build
+    pool:
+      vmImage: 'Ubuntu-16.04'
+    steps:
+    - script: |
+        npx -q git2semver
+      displayName: Generate version number
+    - script: |
+        dotnet restore
+        dotnet build --configuration $(configuration) -p:VersionPrefix=$GIT2SEMVER_MAJORMINORPATCH
+        dotnet test
+        dotnet pack --configuration $(configuration) -p:VersionPrefix=$GIT2SEMVER_MAJORMINORPATCH
+      displayName: Build, test, and package    
+    - task: PublishPipelineArtifact@0
+      inputs:
+        artifactName: drop
+        targetPath: Minimatch/bin/$(configuration)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ jobs:
       vmImage: 'Ubuntu-16.04'
     steps:
     - script: |
-        npx -q git2semver
+        npx -q git2semver@0.7.1
       displayName: Generate version number
     - script: |
         dotnet restore
@@ -19,6 +19,7 @@ jobs:
         dotnet pack --configuration $(configuration) -p:VersionPrefix=$GIT2SEMVER_MAJORMINORPATCH
       displayName: Build, test, and package    
     - task: PublishPipelineArtifact@0
+      displayName: Publish build outputs
       inputs:
         artifactName: drop
         targetPath: Minimatch/bin/$(configuration)

--- a/git2semver.config.js
+++ b/git2semver.config.js
@@ -1,0 +1,4 @@
+module.exports = (policy) => {
+    policy.useMainline('major:', 'minor:', 'patch:');
+    policy.useFormatter('majorminorpatch-pipelines-variables-and-label');
+};


### PR DESCRIPTION
This pull request builds on PR #10. The main thing it does is upgrade the package to build against ```netstandard2.0```.

I also tweaked the semver generation command to use a specific version. This is for security reasons - I realized that without explicitly specifying the version number if someone managed to steal my credentials and publish an updated (and malicious) version of ```git2semver``` that it would be injected directly into your pipeline the next time it runs.

Finally I fixed the license property in the ```*.csproj``` file. The property that was being used translates to a deprecated NuSpec property. I updated it with an expression which maps to the MIT license.